### PR TITLE
Citation and examples that work with this version.

### DIFF
--- a/algol60.scrbl
+++ b/algol60.scrbl
@@ -77,7 +77,7 @@ ASCII, and they are mapped as follows:
    negation          !")
 
 In addition to the standard functions, the following output functions
-are supported, as :
+are supported:
 
 @(verbatim
 "   prints(E)    prints the string E
@@ -85,7 +85,7 @@ are supported, as :
    printn(E)    prints the number E
    printnln(E)  prints the number E followed by a newline")
    
-No oututput procedures were defined by the ``Revised Report on the Algorithmic 
+No output procedures were defined by the ``Revised Report on the Algorithmic 
 Language Algol 60,'' as these were locally implemented by the many Algol 60 
 implementations.
 

--- a/algol60.scrbl
+++ b/algol60.scrbl
@@ -77,14 +77,76 @@ ASCII, and they are mapped as follows:
    negation          !")
 
 In addition to the standard functions, the following output functions
-are supported:
+are supported, as :
 
 @(verbatim
 "   prints(E)    prints the string E
    printsln(E)  prints the string E followed by a newline
    printn(E)    prints the number E
    printnln(E)  prints the number E followed by a newline")
+   
+No oututput procedures were defined by the ``Revised Report on the Algorithmic 
+Language Algol 60,'' as these were locally implemented by the many Algol 60 
+implementations.
 
 A prompt in DrRacket's interactions area accepts whole programs only
 for the Algol 60 language.
+
+@section{Revised report on the algorithmic language ALGOL 60}
+
+J. W. Backus, F. L. Bauer, J. Green, C. Katz, J. McCarthy, P. Naur, A. J. Perlis, 
+H. Rutishauser, K. Samelson, B. Vauquois, J. H. Wegstein, A. van Wijngaarden, 
+M. Woodger, Revised report on the algorithmic language ALGOL 60, The Computer 
+Journal, Volume 5, Issue 4, 1963, Pages 349–367, https://doi.org/10.1093/comjnl/5.4.349
+
+@section{Examples}
+
+@codeblock|{
+
+#lang algol60
+begin
+  printsln(`hello world')
+end
+
+
+#lang algol60
+begin
+  integer n;   
+
+  for n:= 99 step -1 until 2 do
+     begin
+      printn(n);	  
+      prints(` bottles of beer on the wall, ');
+      printn(n);
+      printsln(` bottles of beer.');
+      prints(`Take one down and pass it around,');
+      printn(n-1);
+      printsln(` of beer on the wall...')
+     end;
+  
+  printsln(` 1 bottle of beer on the wall, 1 bottle of beer.\n');
+  printsln(`Take one down and pass it around, no more bottles of beer on the wall...\n\n');
+
+  printsln(`No more bottles of beer on the wall, no more bottles of beer.\n');
+  prints(`Go to the store and buy some more, 99 bottles of beer on the wall.');
+end
+
+
+#lang algol60
+begin
+	comment factorial - algol 60;
+	integer procedure factorial(n); integer n;
+	begin
+		integer i,fact;
+		fact:=1;
+		for i:=2 step 1 until n do
+			fact:=fact*i;
+		factorial:=fact
+	end;
+	integer i;
+	for i:=1 step 1 until 10 do printnln(factorial(i));
+end
+
+
+}|
 


### PR DESCRIPTION
Citation and examples that work with this version.
Most examples online in places like Rosetta Code use outprint, outreal, etc. from later versions of Algol 60.